### PR TITLE
Remove -q args 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          virtualenv venv_35 -q
+          virtualenv venv_35
           source venv_35/bin/activate
           make installdeps
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - run: |
           virtualenv venv_35
           source venv_35/bin/activate
+          pip config --site set global.progress_bar off
           make installdeps
       - run: |
           source venv_35/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ testcoverage: lint
 
 .PHONY: installdeps
 installdeps:
-	pip install --upgrade pip -q
-	pip install -e . -q
-	pip install -r dev-requirements.txt -q
+	pip install --upgrade pip
+	pip install -e .
+	pip install -r dev-requirements.txt
 
 


### PR DESCRIPTION
- We don't generally use the `quiet` arg with pip, and pytest. This PR removes those args. 