### PR TITLE
Migrate tests to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+name: Tests
+jobs:
+  test_all_python_versions:
+    name: Unit Tests - Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.5"]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Install package with test requirements
+        run: |
+          pip config --site set global.progress_bar off
+          make installdeps
+      - name: Run unit tests
+        run: make test addopts="--cov=categorical_encoding"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint-fix:
 
 .PHONY: test
 test:
-	pytest categorical_encoding/tests
+	pytest categorical_encoding/tests ${addopts}
 
 .PHONY: testcoverage
 testcoverage: lint


### PR DESCRIPTION
Closes #16 by migrating tests from CircleCI to GitHub Actions.